### PR TITLE
Upgrade cas module && apache

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -82,7 +82,7 @@ if [ "$CACHED_APACHE_VERSION" != "$APACHE_VERSION" ] || [ "$CACHED_MOD_CAS_VERSI
 	#
 	cd "$BUILD_DIR"
 	info "Downloading mod_cas $MOD_CAS_VERSION"
-	curl -L https://github.com/apereo/mod_auth_cas/archive/v1.1.tar.gz | tar xz
+	curl -L https://github.com/apereo/mod_auth_cas/archive/v${MOD_CAS_VERSION}.tar.gz | tar xz
 	cd "mod_auth_cas-${MOD_CAS_VERSION}"
 	head "Configuring mod_cas $MOD_CAS_VERSION"
 	autoreconf -ivf 2>&1|indent

--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,7 @@ source "$BUILDPACK_HOME/bin/common.sh"
 trap build_failed ERR # Provide hook to deal with errors
 
 if [ -f "$BUILD_DIR/.apache/.apache.cfg" ]; then
-	info "Found $BUILD_DIR/.apache/.apache.cfg" 
+	info "Found $BUILD_DIR/.apache/.apache.cfg"
 	source "$BUILD_DIR/.apache/.apache.cfg"
 fi
 
@@ -113,8 +113,13 @@ fi
 info "Copying Apache $APACHE_VERSION into $BUILD_DIR ..."
 cp -R "$CACHE_DIR/apache" "$BUILD_DIR"
 
-info "Installing configuration files..."
-cp "$BUILDPACK_HOME/config/httpd.conf" $BUILD_DIR/apache/etc/apache2
+if [ -f "$BUILD_DIR/httpd.conf" ]; then
+	info "Using application configuration files..."
+	cp "$BUILD_DIR/httpd.conf" $BUILD_DIR/apache/etc/apache2
+else
+	info "Installing configuration files..."
+	cp "$BUILDPACK_HOME/config/httpd.conf" $BUILD_DIR/apache/etc/apache2
+fi
 
 info "Installing startup script..."
 cp "$BUILDPACK_HOME/bin/boot.sh" $BUILD_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -22,7 +22,7 @@ if [ -f "$BUILD_DIR/.apache/.apache.cfg" ]; then
 fi
 
 if [ -z "$APACHE_VERSION" ]; then
-	APACHE_VERSION="2.4.33"
+	APACHE_VERSION="2.4.38"
 fi
 
 PREFIX_PATH="/app/apache"

--- a/bin/compile
+++ b/bin/compile
@@ -45,7 +45,7 @@ export_env_dir $ENV_DIR
 
 CACHED_APACHE_VERSION=$(cat $CACHE_DIR/apache/.apache-version 2>/dev/null || true)
 CACHED_MOD_CAS_VERSION=$(cat $CACHE_DIR/apache/.mod_cas-version 2>/dev/null || true)
-MOD_CAS_VERSION="1.1"
+MOD_CAS_VERSION="1.2"
 
 if [ "$CACHED_APACHE_VERSION" != "$APACHE_VERSION" ] || [ "$CACHED_MOD_CAS_VERSION" != "$MOD_CAS_VERSION" ]; then
 	info "Apache version changed since last build; old: $CACHED_APACHE_VERSION -> new: $APACHE_VERSION"

--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,4 @@
-/!/usr/bin/env bash
+#!/usr/bin/env bash
 
 ####### Configure environment
 set -e			# fail fast
@@ -57,14 +57,14 @@ if [ "$CACHED_APACHE_VERSION" != "$APACHE_VERSION" ] || [ "$CACHED_MOD_CAS_VERSI
 	cd "$BUILD_DIR"
 
 	info "Downloading Apache $APACHE_VERSION..."
-	curl -L http://www.us.apache.org/dist//httpd/httpd-$APACHE_VERSION.tar.gz | tar xz
+	curl -L https://archive.apache.org/dist/httpd/httpd-$APACHE_VERSION.tar.gz | tar xz
 
 	cd "$APACHE_SRC_DIR"
 	mkdir -p srclib/apr
 	mkdir -p srclib/apr-util
 
-	curl -L http://www.us.apache.org/dist/apr/apr-1.6.3.tar.gz | tar xz -C srclib/apr --strip-components=1
-	curl -L http://www.us.apache.org/dist/apr/apr-util-1.6.1.tar.gz | tar xz -C srclib/apr-util --strip-components=1
+	curl -L https://archive.apache.org/dist/apr/apr-1.6.3.tar.gz | tar xz -C srclib/apr --strip-components=1
+	curl -L https://archive.apache.org/dist/apr/apr-util-1.6.1.tar.gz | tar xz -C srclib/apr-util --strip-components=1
 
 	head "Configuring Apache with args: $CONFIGURE_ARGS"
 	./configure $CONFIGURE_ARGS 2>&1 | indent

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -18,7 +18,7 @@ DocumentRoot /app
 # CASValidateSAML On
 # CASValidateURL https://www.pin1.harvard.edu/cas/samlValidate
 
-# LoadModule authz_core_module libexec/mod_authz_core.so
+LoadModule authz_core_module libexec/mod_authz_core.so
 LoadModule log_config_module libexec/mod_log_config.so
 LoadModule env_module libexec/mod_env.so
 LoadModule unixd_module libexec/mod_unixd.so
@@ -28,8 +28,8 @@ LoadModule proxy_module libexec/mod_proxy.so
 LoadModule proxy_http_module libexec/mod_proxy_http.so
 LoadModule proxy_wstunnel_module libexec/mod_proxy_wstunnel.so
 LoadModule rewrite_module libexec/mod_rewrite.so
-# LoadModule authz_user_module libexec/mod_authz_user.so
-# LoadModule authn_core_module libexec/mod_authn_core.so
+LoadModule authz_user_module libexec/mod_authz_user.so
+LoadModule authn_core_module libexec/mod_authn_core.so
 
 RewriteEngine On
 RewriteCond %{HTTP:Upgrade} =websocket

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -15,7 +15,7 @@ CASLoginURL https://www.pin1.harvard.edu/cas/login
 CASValidateURL https://www.pin1.harvard.edu/cas/serviceValidate
 CASRootProxiedAs https://${CAS_HOSTNAME}
 CASVersion 2
-CASValidateSAML Off
+CASValidateSAML On
 CASValidateURL https://www.pin1.harvard.edu/cas/samlValidate
 
 LoadModule authz_core_module libexec/mod_authz_core.so

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -59,6 +59,11 @@ AccessFileName .htaccess
     CASScope /
 </LocationMatch>
 
+<LocationMatch "^\/(websocket|session)">
+    AuthType CAS
+    CASAuthNHeader X-Auth-Username
+</LocationMatch>
+
 <Directory />
   Options FollowSymLinks Indexes
   AllowOverride None

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -52,11 +52,11 @@ AccessFileName .htaccess
     Require all denied
 </FilesMatch>
 
-<Location "/">
+<LocationMatch "^\/$">
     Require valid-user
     AuthType CAS
     CASAuthNHeader X-Auth-Username
-</Location>
+</LocationMatch>
 
 <Directory />
   Options FollowSymLinks Indexes

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -10,26 +10,26 @@ MaxKeepAliveRequests 100
 KeepAliveTimeout 15
 LimitRequestFieldSize 8190
 DocumentRoot /app
-CASCookiePath /app/apache/var/cache/
-CASLoginURL https://www.pin1.harvard.edu/cas/login
-CASValidateURL https://www.pin1.harvard.edu/cas/serviceValidate
-CASRootProxiedAs https://${CAS_HOSTNAME}
-CASVersion 2
-CASValidateSAML On
-CASValidateURL https://www.pin1.harvard.edu/cas/samlValidate
+# CASCookiePath /app/apache/var/cache/
+# CASLoginURL https://www.pin1.harvard.edu/cas/login
+# CASValidateURL https://www.pin1.harvard.edu/cas/serviceValidate
+# CASRootProxiedAs https://${CAS_HOSTNAME}
+# CASVersion 2
+# CASValidateSAML On
+# CASValidateURL https://www.pin1.harvard.edu/cas/samlValidate
 
-LoadModule authz_core_module libexec/mod_authz_core.so
+# LoadModule authz_core_module libexec/mod_authz_core.so
 LoadModule log_config_module libexec/mod_log_config.so
 LoadModule env_module libexec/mod_env.so
 LoadModule unixd_module libexec/mod_unixd.so
 LoadModule dir_module libexec/mod_dir.so
-LoadModule auth_cas_module libexec/mod_auth_cas.so
+# LoadModule auth_cas_module libexec/mod_auth_cas.so
 LoadModule proxy_module libexec/mod_proxy.so
 LoadModule proxy_http_module libexec/mod_proxy_http.so
 LoadModule proxy_wstunnel_module libexec/mod_proxy_wstunnel.so
 LoadModule rewrite_module libexec/mod_rewrite.so
-LoadModule authz_user_module libexec/mod_authz_user.so
-LoadModule authn_core_module libexec/mod_authn_core.so
+# LoadModule authz_user_module libexec/mod_authz_user.so
+# LoadModule authn_core_module libexec/mod_authn_core.so
 
 RewriteEngine On
 RewriteCond %{HTTP:Upgrade} =websocket
@@ -51,12 +51,6 @@ AccessFileName .htaccess
 <FilesMatch "^\.ht">
     Require all denied
 </FilesMatch>
-
-<Location "/">
-    Require valid-user
-    AuthType CAS
-    CASAuthNHeader X-Auth-Username
-</Location>
 
 <Directory />
   Options FollowSymLinks Indexes

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -15,7 +15,7 @@ CASLoginURL https://www.pin1.harvard.edu/cas/login
 CASValidateURL https://www.pin1.harvard.edu/cas/serviceValidate
 CASRootProxiedAs https://${CAS_HOSTNAME}
 CASVersion 2
-CASValidateSAML On
+CASValidateSAML Off
 CASValidateURL https://www.pin1.harvard.edu/cas/samlValidate
 
 LoadModule authz_core_module libexec/mod_authz_core.so

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -17,7 +17,6 @@ CASRootProxiedAs https://${CAS_HOSTNAME}
 CASVersion 2
 CASValidateSAML On
 CASValidateURL https://www.pin1.harvard.edu/cas/samlValidate
-CASScope /
 
 LoadModule authz_core_module libexec/mod_authz_core.so
 LoadModule log_config_module libexec/mod_log_config.so
@@ -57,6 +56,7 @@ AccessFileName .htaccess
     Require valid-user
     AuthType CAS
     CASAuthNHeader X-Auth-Username
+    CASScope /
 </LocationMatch>
 
 <Directory />

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -17,6 +17,7 @@ CASRootProxiedAs https://${CAS_HOSTNAME}
 CASVersion 2
 CASValidateSAML On
 CASValidateURL https://www.pin1.harvard.edu/cas/samlValidate
+CASScope /
 
 LoadModule authz_core_module libexec/mod_authz_core.so
 LoadModule log_config_module libexec/mod_log_config.so

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -59,9 +59,11 @@ AccessFileName .htaccess
     CASScope /
 </LocationMatch>
 
-<LocationMatch "^\/(websocket|session)">
+<LocationMatch "^\/(websocket|session).*">
+    Require valid-user
     AuthType CAS
     CASAuthNHeader X-Auth-Username
+    CASScope /
 </LocationMatch>
 
 <Directory />


### PR DESCRIPTION
This change updates the CAS module to latest 1.2 and Apache to latest 2.4.38. Tested on https://evan-shiny-buildpack.herokuapp.com.

Please tag v1.1 upon acceptance.